### PR TITLE
Add zone filtering to sidebar and map highlight

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,13 +12,14 @@ import {
   ListItemText,
   Divider,
   Box,
-  Switch,
-  FormControlLabel,
   createTheme,
   ThemeProvider,
   Button,
+  ToggleButton,
+  ToggleButtonGroup,
+  Chip,
 } from "@mui/material";
-import { Menu as MenuIcon, LocationCity, Map } from "@mui/icons-material";
+import { Menu as MenuIcon, LocationCity, Map, Layers } from "@mui/icons-material";
 import { Routes, Route, useNavigate } from "react-router-dom";
 import axios from "axios";
 import MapView, { type MapSelection } from "./components/MapView";
@@ -53,15 +54,36 @@ const darkTheme = createTheme({
 });
 
 type City = { City_Code: number; City_Name: string };
+type Department = {
+  Department_Code: string;
+  Department_Name: string;
+  SQM: number | null;
+  Longitude: number | null;
+  Latitude: number | null;
+  Adresse: string | null;
+  Format: string | null;
+  City_Name?: string | null;
+  Area_Code?: string | null;
+  Area_Name?: string | null;
+  Zone_Code?: string | null;
+  Zone_Name?: string | null;
+};
+
 type Area = {
   Area_Code: string;
   Area_Name: string;
+  Zone_Code?: string | null;
+  Zone_Name?: string | null;
   Cities: string[];
-  Departments: {
-    Department_Code: string;
-    Department_Name: string;
-    SQM: number;
-  }[];
+  Departments: Department[];
+};
+
+type Zone = {
+  Zone_Code: string | null;
+  Zone_Name: string;
+  Areas: string[];
+  Cities: string[];
+  Departments: Department[];
 };
 
 type SidebarCityItem = { code: number; name: string; type: "city" };
@@ -70,31 +92,51 @@ type SidebarAreaItem = {
   name: string;
   type: "area";
   cities: string[];
-  Departments: Area["Departments"];
+  Departments: Department[];
+  zoneName?: string | null;
+};
+type SidebarZoneItem = {
+  code: string;
+  name: string;
+  type: "zone";
+  cities: string[];
+  areas: string[];
+  Departments: Department[];
 };
 
-type SidebarItem = SidebarCityItem | SidebarAreaItem;
+type SidebarItem = SidebarCityItem | SidebarAreaItem | SidebarZoneItem;
 
 export default function App() {
-  const [filterByCity, setFilterByCity] = useState(true);
+  const [filterMode, setFilterMode] = useState<"city" | "area" | "zone">(
+    "city"
+  );
   const [selectedItem, setSelectedItem] = useState<SidebarItem | null>(null);
   const [cityList, setCityList] = useState<City[]>([]);
   const [areaList, setAreaList] = useState<Area[]>([]);
+  const [zoneList, setZoneList] = useState<Zone[]>([]);
   const navigate = useNavigate();
 
   // Load cities and areas
   useEffect(() => {
     axios
-      .get("http://localhost:4000/api/cities")
+      .get<City[]>("http://localhost:4000/api/cities")
       .then((res) => setCityList(res.data));
     axios
-      .get("http://localhost:4000/api/areas/filters")
+      .get<Area[]>("http://localhost:4000/api/areas/filters")
       .then((res) => setAreaList(res.data));
+    axios
+      .get<Zone[]>("http://localhost:4000/api/zones")
+      .then((res) => setZoneList(res.data));
   }, []);
 
-  const handleToggle = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setFilterByCity(event.target.checked);
-    setSelectedItem(null);
+  const handleFilterModeChange = (
+    _event: React.MouseEvent<HTMLElement>,
+    nextMode: "city" | "area" | "zone" | null
+  ) => {
+    if (nextMode) {
+      setFilterMode(nextMode);
+      setSelectedItem(null);
+    }
   };
 
   const handleSelect = (item: SidebarItem) => {
@@ -108,22 +150,34 @@ export default function App() {
     setSelectedItem(null);
   };
 
-  const mapSelection: MapSelection | null = filterByCity
-    ? selectedItem?.type === "city"
-      ? { mode: "city", city: selectedItem.name }
-      : null
-    : selectedItem?.type === "area"
-      ? {
-          mode: "area",
-          area: selectedItem.name,
-          cities: selectedItem.cities,
-        }
-      : null;
+  let mapSelection: MapSelection | null = null;
+  if (selectedItem?.type === "city") {
+    mapSelection = { mode: "city", city: selectedItem.name };
+  } else if (selectedItem?.type === "area" && filterMode === "area") {
+    mapSelection = {
+      mode: "area",
+      area: selectedItem.name,
+      cities: selectedItem.cities,
+    };
+  } else if (selectedItem?.type === "zone" && filterMode === "zone") {
+    mapSelection = {
+      mode: "zone",
+      zone: selectedItem.name,
+      cities: selectedItem.cities,
+      areas: selectedItem.areas,
+    };
+  }
 
   // Sidebar content
   let drawerContent;
   const areaItem =
-    !filterByCity && selectedItem?.type === "area" ? selectedItem : null;
+    filterMode === "area" && selectedItem?.type === "area"
+      ? selectedItem
+      : null;
+  const zoneItem =
+    filterMode === "zone" && selectedItem?.type === "zone"
+      ? selectedItem
+      : null;
 
   if (areaItem) {
     // Detail mode (Area with departments)
@@ -142,6 +196,9 @@ export default function App() {
           <Typography variant="h6">{areaItem.name}</Typography>
           <Typography variant="body2" sx={{ color: "text.secondary" }}>
             Cities: {areaItem.cities.join(", ")}
+          </Typography>
+          <Typography variant="body2" sx={{ color: "text.secondary" }}>
+            Zone: {areaItem.zoneName ?? "Unassigned"}
           </Typography>
         </Box>
 
@@ -175,8 +232,27 @@ export default function App() {
                     variant="caption"
                     sx={{ color: "text.secondary", display: "block" }}
                   >
-                    Madhesia Pikes: {department.SQM}
+                    Madhesia Pikes: {" "}
+                    {department.SQM != null
+                      ? department.SQM.toLocaleString()
+                      : "N/A"}
                   </Typography>
+                  {department.City_Name && (
+                    <Typography
+                      variant="caption"
+                      sx={{ color: "text.secondary", display: "block" }}
+                    >
+                      City: {department.City_Name}
+                    </Typography>
+                  )}
+                  {department.Format && (
+                    <Typography
+                      variant="caption"
+                      sx={{ color: "text.secondary", display: "block" }}
+                    >
+                      Format: {department.Format}
+                    </Typography>
+                  )}
                 </CardContent>
               </CardActionArea>
             </Card>
@@ -184,21 +260,122 @@ export default function App() {
         </Box>
       </Box>
     );
+  } else if (zoneItem) {
+    drawerContent = (
+      <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+        <Toolbar />
+        <Box sx={{ px: 2, py: 1 }}>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleBack}
+            sx={{ mb: 2 }}
+          >
+            ← Back to Zones
+          </Button>
+          <Typography variant="h6">{zoneItem.name}</Typography>
+          <Typography variant="body2" sx={{ color: "text.secondary", mt: 1 }}>
+            Areas covered
+          </Typography>
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 0.5 }}>
+            {zoneItem.areas.map((area) => (
+              <Chip key={area} label={area} size="small" />
+            ))}
+          </Box>
+          <Typography variant="body2" sx={{ color: "text.secondary", mt: 1 }}>
+            Cities linked
+          </Typography>
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 0.5 }}>
+            {zoneItem.cities.map((city) => (
+              <Chip key={city} label={city} size="small" color="primary" />
+            ))}
+          </Box>
+        </Box>
+
+        <Divider />
+        <Box sx={{ flex: 1, overflowY: "auto", px: 2, py: 1 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Stores in this zone
+          </Typography>
+          {zoneItem.Departments.map((department) => (
+            <Card
+              key={`${department.Department_Code}-${department.Area_Code}`}
+              variant="outlined"
+              sx={{
+                mb: 1.5,
+                borderRadius: 2,
+                bgcolor: "background.default",
+                "&:hover": { boxShadow: 3, borderColor: "primary.main" },
+              }}
+            >
+              <CardContent>
+                <Typography variant="body2" fontWeight="bold">
+                  {department.Department_Name}
+                </Typography>
+                <Typography
+                  variant="caption"
+                  sx={{ color: "text.secondary", display: "block" }}
+                >
+                  {department.Area_Name || "Unknown area"} · {" "}
+                  {department.City_Name || "Unknown city"}
+                </Typography>
+                {department.Zone_Name && (
+                  <Typography
+                    variant="caption"
+                    sx={{ color: "text.secondary", display: "block" }}
+                  >
+                    Zone: {department.Zone_Name}
+                  </Typography>
+                )}
+                <Typography
+                  variant="caption"
+                  sx={{ color: "text.secondary", display: "block" }}
+                >
+                  Madhesia Pikes: {" "}
+                  {department.SQM != null
+                    ? department.SQM.toLocaleString()
+                    : "N/A"}
+                </Typography>
+                {department.Format && (
+                  <Typography
+                    variant="caption"
+                    sx={{ color: "text.secondary", display: "block" }}
+                  >
+                    Format: {department.Format}
+                  </Typography>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </Box>
+      </Box>
+    );
   } else {
     // City/Area list mode
-    const items: SidebarItem[] = filterByCity
-      ? cityList.map((c) => ({
-          code: c.City_Code,
-          name: c.City_Name,
-          type: "city" as const,
-        }))
-      : areaList.map((a) => ({
-          code: a.Area_Code,
-          name: a.Area_Name,
-          cities: a.Cities,
-          Departments: a.Departments,
-          type: "area" as const,
-        }));
+    const items: SidebarItem[] =
+      filterMode === "city"
+        ? cityList.map((c) => ({
+            code: c.City_Code,
+            name: c.City_Name,
+            type: "city" as const,
+          }))
+        : filterMode === "area"
+        ? areaList.map((a) => ({
+            code: a.Area_Code,
+            name: a.Area_Name,
+            cities: a.Cities,
+            Departments: a.Departments,
+            zoneName: a.Zone_Name,
+            type: "area" as const,
+          }))
+        : zoneList.map((z) => ({
+            code: z.Zone_Code ?? `zone-${z.Zone_Name}`,
+            name: z.Zone_Name,
+            cities: z.Cities,
+            areas: z.Areas,
+            Departments: z.Departments,
+            type: "zone" as const,
+          }));
 
     drawerContent = (
       <Box
@@ -211,16 +388,18 @@ export default function App() {
       >
         <Toolbar />
         <Box sx={{ px: 2, py: 1 }}>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={filterByCity}
-                onChange={handleToggle}
-                color="primary"
-              />
-            }
-            label={filterByCity ? "Filter by City" : "Filter by Area"}
-          />
+          <ToggleButtonGroup
+            value={filterMode}
+            exclusive
+            fullWidth
+            onChange={handleFilterModeChange}
+            size="small"
+            color="primary"
+          >
+            <ToggleButton value="city">Cities</ToggleButton>
+            <ToggleButton value="area">Areas</ToggleButton>
+            <ToggleButton value="zone">Zones</ToggleButton>
+          </ToggleButtonGroup>
         </Box>
 
         <Box sx={{ px: 1, py: 1, flex: 1, overflowY: "auto" }}>
@@ -241,7 +420,13 @@ export default function App() {
                 }}
               >
                 <ListItemIcon sx={{ color: "text.secondary" }}>
-                  {filterByCity ? <LocationCity /> : <Map />}
+                  {filterMode === "city" ? (
+                    <LocationCity />
+                  ) : filterMode === "area" ? (
+                    <Map />
+                  ) : (
+                    <Layers />
+                  )}
                 </ListItemIcon>
                 <ListItemText primary={item.name} />
               </ListItemButton>

--- a/vivabackend/routes/areas.js
+++ b/vivabackend/routes/areas.js
@@ -7,9 +7,11 @@ router.get("/", async (req, res) => {
   try {
     const pool = await getPool();
     const result = await pool.request().query(`
-      SELECT DISTINCT 
+      SELECT DISTINCT
         o.Area_Code,
         LTRIM(RIGHT(o.Area_Name, LEN(o.Area_Name) - CHARINDEX('-', o.Area_Name))) AS Area_Name,
+        o.Zone_Code,
+        LTRIM(RTRIM(o.Zone_Name)) AS Zone_Name,
         o.Department_Code,
         o.Department_Name,
         o.City_Name,

--- a/vivabackend/routes/combined.js
+++ b/vivabackend/routes/combined.js
@@ -66,9 +66,11 @@ router.get("/stores-with-businesses", async (req, res) => {
     const pool = await getPool();
 
     const result = await pool.request().query(`
-      SELECT DISTINCT 
+      SELECT DISTINCT
         o.Area_Code,
         LTRIM(RIGHT(o.Area_Name, LEN(o.Area_Name) - CHARINDEX('-', o.Area_Name))) AS Area_Name,
+        o.Zone_Code,
+        LTRIM(RTRIM(o.Zone_Name)) AS Zone_Name,
         o.Department_Code,
         o.Department_Name,
         o.City_Name,

--- a/vivabackend/server.js
+++ b/vivabackend/server.js
@@ -6,6 +6,7 @@ import citiesRoutes from "./routes/cities.js";
 import areasRoutes from "./routes/areas.js";
 import regionsRoutes from "./routes/regions.js";
 import filtersRoutes from "./routes/filters.js";
+import zonesRoutes from "./routes/zones.js";
 import osmRoutes from "./routes/osm.js";
 import combinedRoutes from "./routes/combined.js";
 
@@ -18,6 +19,7 @@ app.use("/api/cities", citiesRoutes);
 app.use("/api/areas", areasRoutes);
 app.use("/api/regions", regionsRoutes);
 app.use("/api/areas/filters", filtersRoutes);
+app.use("/api/zones", zonesRoutes);
 app.use("/api/osm", osmRoutes);
 app.use("/api/combined", combinedRoutes);
 


### PR DESCRIPTION
## Summary
- add backend zone endpoint and include zone metadata on area and store queries
- extend sidebar to support city, area, and zone filter modes with richer detail panes
- wire map selection logic to highlight stores and cities by zone and expose new summary data

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c90d085fb08324b6b72adec55a0ad7