### PR TITLE
Enhance sidebar filtering and map data integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,11 +18,13 @@ import {
   ToggleButton,
   ToggleButtonGroup,
   Chip,
+  Stack,
+  CircularProgress,
 } from "@mui/material";
-import { Menu as MenuIcon, LocationCity, Map, Layers } from "@mui/icons-material";
+import { Menu as MenuIcon, LocationCity, Map as MapIcon, Layers } from "@mui/icons-material";
 import { Routes, Route, useNavigate } from "react-router-dom";
 import axios from "axios";
-import MapView, { type MapSelection } from "./components/MapView";
+import MapView, { type MapSelection, type StoreData } from "./components/MapView";
 import ReportView from "./components/ReportView";
 
 const drawerWidth = 300;
@@ -54,6 +56,7 @@ const darkTheme = createTheme({
 });
 
 type City = { City_Code: number; City_Name: string };
+
 type Department = {
   Department_Code: string;
   Department_Name: string;
@@ -67,44 +70,90 @@ type Department = {
   Area_Name?: string | null;
   Zone_Code?: string | null;
   Zone_Name?: string | null;
+  Region_Code?: string | null;
+  Region_Name?: string | null;
 };
 
-type Area = {
+type RawAreaResponse = {
   Area_Code: string;
   Area_Name: string;
-  Zone_Code?: string | null;
-  Zone_Name?: string | null;
   Cities: string[];
   Departments: Department[];
 };
 
-type Zone = {
+type RawZoneRecord = {
   Zone_Code: string | null;
   Zone_Name: string;
-  Areas: string[];
-  Cities: string[];
-  Departments: Department[];
+  Area_Code: string | null;
+  Area_Name: string;
+  City_Name: string | null;
+  Region_Code: string | null;
+  Region_Name: string | null;
+  SQM: number | null;
+  Longitude: number | null;
+  Latitude: number | null;
+  Adresse: string | null;
+  Format: string | null;
 };
 
-type SidebarCityItem = { code: number; name: string; type: "city" };
+type SidebarCityItem = {
+  code: number;
+  name: string;
+  type: "city";
+  storeCount: number;
+  totalSqm: number;
+  areaCount: number;
+  geocodedCount: number;
+};
+
 type SidebarAreaItem = {
   code: string;
   name: string;
   type: "area";
   cities: string[];
-  Departments: Department[];
-  zoneName?: string | null;
+  departments: Department[];
+  zoneNames: string[];
+  storeCount: number;
+  totalSqm: number;
+  geocodedCount: number;
 };
+
 type SidebarZoneItem = {
   code: string;
   name: string;
   type: "zone";
   cities: string[];
   areas: string[];
-  Departments: Department[];
+  departments: Department[];
+  regionNames: string[];
+  storeCount: number;
+  totalSqm: number;
+  geocodedCount: number;
 };
 
 type SidebarItem = SidebarCityItem | SidebarAreaItem | SidebarZoneItem;
+
+type ZoneGroup = {
+  code: string;
+  name: string;
+  departments: Department[];
+  cities: Set<string>;
+  areas: Set<string>;
+  regionNames: Set<string>;
+  totalSqm: number;
+  geocodedCount: number;
+};
+
+const formatNumber = new Intl.NumberFormat("en-US");
+const normalizeKey = (value: string) => value.trim().toLowerCase();
+const sortByStoreCount = <T extends { storeCount: number; name: string }>(
+  list: T[]
+) =>
+  list
+    .slice()
+    .sort(
+      (a, b) => b.storeCount - a.storeCount || a.name.localeCompare(b.name)
+    );
 
 export default function App() {
   const [filterMode, setFilterMode] = useState<"city" | "area" | "zone">(
@@ -112,21 +161,267 @@ export default function App() {
   );
   const [selectedItem, setSelectedItem] = useState<SidebarItem | null>(null);
   const [cityList, setCityList] = useState<City[]>([]);
-  const [areaList, setAreaList] = useState<Area[]>([]);
-  const [zoneList, setZoneList] = useState<Zone[]>([]);
+  const [cityItems, setCityItems] = useState<SidebarCityItem[]>([]);
+  const [areaItems, setAreaItems] = useState<SidebarAreaItem[]>([]);
+  const [zoneItems, setZoneItems] = useState<SidebarZoneItem[]>([]);
+  const [storesForMap, setStoresForMap] = useState<StoreData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
 
-  // Load cities and areas
+  // Load cities, areas and zone structures from the API and
+  // reshape them for the sidebar + map experience.
   useEffect(() => {
-    axios
-      .get<City[]>("http://localhost:4000/api/cities")
-      .then((res) => setCityList(res.data));
-    axios
-      .get<Area[]>("http://localhost:4000/api/areas/filters")
-      .then((res) => setAreaList(res.data));
-    axios
-      .get<Zone[]>("http://localhost:4000/api/zones")
-      .then((res) => setZoneList(res.data));
+    let cancelled = false;
+
+    const loadData = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const [citiesRes, areasRes, zonesRes] = await Promise.all([
+          axios.get<City[]>("http://localhost:4000/api/cities"),
+          axios.get<RawAreaResponse[]>("http://localhost:4000/api/areas/filters"),
+          axios.get<RawZoneRecord[]>("http://localhost:4000/api/zones"),
+        ]);
+
+        if (cancelled) {
+          return;
+        }
+
+        setCityList(citiesRes.data);
+
+        const zoneByDepartment = new Map<string, RawZoneRecord>();
+        for (const record of zonesRes.data) {
+          const rawKey = record.Zone_Code ?? record.Zone_Name;
+          if (!rawKey) {
+            continue;
+          }
+          const key = String(rawKey).trim();
+          if (key.length === 0) {
+            continue;
+          }
+          zoneByDepartment.set(key, record);
+        }
+
+        const processedAreas = areasRes.data.map((area) => {
+          const departments = area.Departments.map((department) => {
+            const departmentCode = String(department.Department_Code);
+            const zoneRecord = zoneByDepartment.get(departmentCode);
+            const zoneCode = zoneRecord?.Zone_Code
+              ? String(zoneRecord.Zone_Code)
+              : departmentCode || null;
+            const zoneName = zoneRecord?.Zone_Name ?? null;
+
+            return {
+              ...department,
+              Department_Code: departmentCode,
+              City_Name: department.City_Name ?? null,
+              Area_Code: area.Area_Code,
+              Area_Name: area.Area_Name,
+              Zone_Code: zoneCode,
+              Zone_Name: zoneName,
+              Region_Code: zoneRecord?.Region_Code ?? null,
+              Region_Name: zoneRecord?.Region_Name ?? null,
+            } satisfies Department;
+          });
+
+          const totalSqm = departments.reduce(
+            (sum, dept) => sum + (dept.SQM ?? 0),
+            0
+          );
+          const geocodedCount = departments.filter(
+            (dept) => dept.Longitude !== null && dept.Latitude !== null
+          ).length;
+          const zoneNames = Array.from(
+            new Set(
+              departments
+                .map((dept) => (dept.Zone_Name ?? "").trim())
+                .filter((name) => name.length > 0)
+            )
+          ).sort();
+
+          return {
+            code: area.Area_Code,
+            name: area.Area_Name,
+            type: "area" as const,
+            cities: area.Cities.slice().sort((a, b) => a.localeCompare(b)),
+            departments,
+            zoneNames,
+            storeCount: departments.length,
+            totalSqm,
+            geocodedCount,
+          } satisfies SidebarAreaItem;
+        });
+
+        const zoneGroups: Map<string, ZoneGroup> = new Map();
+
+        for (const record of zonesRes.data) {
+          const baseCode = record.Zone_Code ?? record.Zone_Name;
+          const zoneCodeRaw = String(baseCode ?? `zone-${record.Zone_Name}`).trim();
+          const zoneCode = zoneCodeRaw.length > 0 ? zoneCodeRaw : `zone-${record.Zone_Name}`;
+          const zoneName = record.Zone_Name?.trim() || "Unassigned zone";
+
+          let group = zoneGroups.get(zoneCode);
+          if (!group) {
+            group = {
+              code: zoneCode,
+              name: zoneName,
+              departments: [],
+              cities: new Set<string>(),
+              areas: new Set<string>(),
+              regionNames: new Set<string>(),
+              totalSqm: 0,
+              geocodedCount: 0,
+            };
+            zoneGroups.set(zoneCode, group);
+          }
+
+          const department: Department = {
+            Department_Code: zoneCode,
+            Department_Name: zoneName,
+            SQM: record.SQM,
+            Longitude: record.Longitude,
+            Latitude: record.Latitude,
+            Adresse: record.Adresse,
+            Format: record.Format,
+            City_Name: record.City_Name,
+            Area_Code: record.Area_Code,
+            Area_Name: record.Area_Name,
+            Zone_Code: zoneCode,
+            Zone_Name: zoneName,
+            Region_Code: record.Region_Code,
+            Region_Name: record.Region_Name,
+          };
+
+          group.departments.push(department);
+          if (record.City_Name) group.cities.add(record.City_Name);
+          if (record.Area_Name) group.areas.add(record.Area_Name);
+          if (record.Region_Name) group.regionNames.add(record.Region_Name);
+          group.totalSqm += record.SQM ?? 0;
+          if (record.Latitude !== null && record.Longitude !== null) {
+            group.geocodedCount += 1;
+          }
+        }
+
+        const zoneValues = Array.from(zoneGroups.values());
+        const processedZones = sortByStoreCount(
+          zoneValues.map((group): SidebarZoneItem => ({
+            code: group.code,
+            name: group.name,
+            type: "zone",
+            cities: Array.from(group.cities).sort((a, b) => a.localeCompare(b)),
+            areas: Array.from(group.areas).sort((a, b) => a.localeCompare(b)),
+            departments: group.departments,
+            regionNames: Array.from(group.regionNames).sort((a, b) =>
+              a.localeCompare(b)
+            ),
+            storeCount: group.departments.length,
+            totalSqm: group.totalSqm,
+            geocodedCount: group.geocodedCount,
+          }))
+        );
+
+        const allDepartments = processedAreas.flatMap((area) => area.departments);
+        const cityMetrics = new Map<
+          string,
+          {
+            storeCount: number;
+            totalSqm: number;
+            areaNames: Set<string>;
+            geocodedCount: number;
+          }
+        >();
+
+        for (const department of allDepartments) {
+          const cityName = department.City_Name?.trim();
+          if (!cityName) {
+            continue;
+          }
+
+          const key = normalizeKey(cityName);
+          let metrics = cityMetrics.get(key);
+          if (!metrics) {
+            metrics = {
+              storeCount: 0,
+              totalSqm: 0,
+              areaNames: new Set<string>(),
+              geocodedCount: 0,
+            };
+            cityMetrics.set(key, metrics);
+          }
+
+          metrics.storeCount += 1;
+          metrics.totalSqm += department.SQM ?? 0;
+          if (department.Area_Name) {
+            metrics.areaNames.add(department.Area_Name);
+          }
+          if (department.Longitude !== null && department.Latitude !== null) {
+            metrics.geocodedCount += 1;
+          }
+        }
+
+        const processedCities = sortByStoreCount(
+          citiesRes.data.map((city) => {
+            const metrics = cityMetrics.get(normalizeKey(city.City_Name));
+            return {
+              code: city.City_Code,
+              name: city.City_Name,
+              type: "city" as const,
+              storeCount: metrics?.storeCount ?? 0,
+              totalSqm: metrics?.totalSqm ?? 0,
+              areaCount: metrics ? metrics.areaNames.size : 0,
+              geocodedCount: metrics?.geocodedCount ?? 0,
+            } satisfies SidebarCityItem;
+          })
+        );
+
+        const storeMap = new Map<string, StoreData>();
+        for (const department of allDepartments) {
+          const key = String(department.Department_Code);
+          if (!key || storeMap.has(key)) {
+            continue;
+          }
+
+          storeMap.set(key, {
+            Area_Code: department.Area_Code ?? "",
+            Area_Name: department.Area_Name ?? "Unknown area",
+            Department_Code: key,
+            Department_Name: department.Department_Name,
+            SQM: department.SQM,
+            Longitude: department.Longitude,
+            Latitude: department.Latitude,
+            Adresse: department.Adresse,
+            Format: department.Format,
+            City_Name: department.City_Name ?? undefined,
+            Zone_Code: department.Zone_Code ?? undefined,
+            Zone_Name: department.Zone_Name ?? undefined,
+          });
+        }
+
+        if (!cancelled) {
+          setCityItems(processedCities);
+          setAreaItems(sortByStoreCount(processedAreas));
+          setZoneItems(processedZones);
+          setStoresForMap(Array.from(storeMap.values()));
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError("Unable to load Viva Fresh insights. Please retry.");
+          console.error("Failed to load Viva Fresh data", err);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadData();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const handleFilterModeChange = (
@@ -180,6 +475,21 @@ export default function App() {
       : null;
 
   if (areaItem) {
+    const areaGeoCoverage =
+      areaItem.storeCount > 0
+        ? Math.round((areaItem.geocodedCount / areaItem.storeCount) * 100)
+        : 0;
+    const zoneChipLabel =
+      areaItem.zoneNames.length === 0
+        ? "Zone: Unassigned"
+        : areaItem.zoneNames.length === 1
+        ? `Zone: ${areaItem.zoneNames[0]}`
+        : `${areaItem.zoneNames.length} zones`;
+    const geoChipLabel =
+      areaItem.storeCount > 0
+        ? `Geo ${areaItem.geocodedCount}/${areaItem.storeCount} (${areaGeoCoverage}%)`
+        : "Geo data pending";
+
     // Detail mode (Area with departments)
     drawerContent = (
       <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
@@ -193,22 +503,41 @@ export default function App() {
           >
             ← Back to Areas
           </Button>
-          <Typography variant="h6">{areaItem.name}</Typography>
-          <Typography variant="body2" sx={{ color: "text.secondary" }}>
-            Cities: {areaItem.cities.join(", ")}
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            {areaItem.name}
           </Typography>
-          <Typography variant="body2" sx={{ color: "text.secondary" }}>
-            Zone: {areaItem.zoneName ?? "Unassigned"}
+          <Stack direction="row" spacing={1} flexWrap="wrap" sx={{ mt: 1 }}>
+            <Chip
+              size="small"
+              color="primary"
+              label={`${areaItem.storeCount} ${
+                areaItem.storeCount === 1 ? "store" : "stores"
+              }`}
+            />
+            {areaItem.totalSqm > 0 && (
+              <Chip
+                size="small"
+                variant="outlined"
+                label={`${formatNumber.format(areaItem.totalSqm)} m²`}
+              />
+            )}
+            <Chip size="small" variant="outlined" label={geoChipLabel} />
+            <Chip size="small" variant="outlined" label={zoneChipLabel} />
+          </Stack>
+          <Typography variant="body2" sx={{ color: "text.secondary", mt: 1 }}>
+            {areaItem.cities.length > 0
+              ? `Cities: ${areaItem.cities.join(", ")}`
+              : "No linked cities yet"}
           </Typography>
         </Box>
 
         <Divider />
         <Box sx={{ flex: 1, overflowY: "auto", px: 2, py: 1 }}>
           <Typography variant="subtitle2" gutterBottom>
-            Departments
+            Viva Fresh locations
           </Typography>
 
-          {areaItem.Departments?.map((department) => (
+          {areaItem.departments.map((department) => (
             <Card
               key={department.Department_Code}
               variant="outlined"
@@ -232,9 +561,9 @@ export default function App() {
                     variant="caption"
                     sx={{ color: "text.secondary", display: "block" }}
                   >
-                    Madhesia Pikes: {" "}
+                    Store area:{" "}
                     {department.SQM != null
-                      ? department.SQM.toLocaleString()
+                      ? `${formatNumber.format(department.SQM)} m²`
                       : "N/A"}
                   </Typography>
                   {department.City_Name && (
@@ -243,6 +572,14 @@ export default function App() {
                       sx={{ color: "text.secondary", display: "block" }}
                     >
                       City: {department.City_Name}
+                    </Typography>
+                  )}
+                  {department.Zone_Name && (
+                    <Typography
+                      variant="caption"
+                      sx={{ color: "text.secondary", display: "block" }}
+                    >
+                      Zone: {department.Zone_Name}
                     </Typography>
                   )}
                   {department.Format && (
@@ -261,6 +598,17 @@ export default function App() {
       </Box>
     );
   } else if (zoneItem) {
+    const zoneGeoCoverage =
+      zoneItem.storeCount > 0
+        ? Math.round((zoneItem.geocodedCount / zoneItem.storeCount) * 100)
+        : 0;
+    const regionChipLabel =
+      zoneItem.regionNames.length === 0
+        ? "Region: Unassigned"
+        : zoneItem.regionNames.length === 1
+        ? `Region: ${zoneItem.regionNames[0]}`
+        : `${zoneItem.regionNames.length} regions`;
+
     drawerContent = (
       <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
         <Toolbar />
@@ -273,7 +621,31 @@ export default function App() {
           >
             ← Back to Zones
           </Button>
-          <Typography variant="h6">{zoneItem.name}</Typography>
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            {zoneItem.name}
+          </Typography>
+          <Stack direction="row" spacing={1} flexWrap="wrap" sx={{ mt: 1 }}>
+            <Chip
+              size="small"
+              color="primary"
+              label={`${zoneItem.storeCount} ${
+                zoneItem.storeCount === 1 ? "store" : "stores"
+              }`}
+            />
+            {zoneItem.totalSqm > 0 && (
+              <Chip
+                size="small"
+                variant="outlined"
+                label={`${formatNumber.format(zoneItem.totalSqm)} m²`}
+              />
+            )}
+            <Chip
+              size="small"
+              variant="outlined"
+              label={`Geo ${zoneItem.geocodedCount}/${zoneItem.storeCount || 1} (${zoneGeoCoverage}%)`}
+            />
+            <Chip size="small" variant="outlined" label={regionChipLabel} />
+          </Stack>
           <Typography variant="body2" sx={{ color: "text.secondary", mt: 1 }}>
             Areas covered
           </Typography>
@@ -297,7 +669,7 @@ export default function App() {
           <Typography variant="subtitle2" gutterBottom>
             Stores in this zone
           </Typography>
-          {zoneItem.Departments.map((department) => (
+          {zoneItem.departments.map((department) => (
             <Card
               key={`${department.Department_Code}-${department.Area_Code}`}
               variant="outlined"
@@ -319,21 +691,13 @@ export default function App() {
                   {department.Area_Name || "Unknown area"} · {" "}
                   {department.City_Name || "Unknown city"}
                 </Typography>
-                {department.Zone_Name && (
-                  <Typography
-                    variant="caption"
-                    sx={{ color: "text.secondary", display: "block" }}
-                  >
-                    Zone: {department.Zone_Name}
-                  </Typography>
-                )}
                 <Typography
                   variant="caption"
                   sx={{ color: "text.secondary", display: "block" }}
                 >
-                  Madhesia Pikes: {" "}
+                  Store area:{" "}
                   {department.SQM != null
-                    ? department.SQM.toLocaleString()
+                    ? `${formatNumber.format(department.SQM)} m²`
                     : "N/A"}
                 </Typography>
                 {department.Format && (
@@ -354,28 +718,89 @@ export default function App() {
     // City/Area list mode
     const items: SidebarItem[] =
       filterMode === "city"
-        ? cityList.map((c) => ({
-            code: c.City_Code,
-            name: c.City_Name,
-            type: "city" as const,
-          }))
+        ? cityItems
         : filterMode === "area"
-        ? areaList.map((a) => ({
-            code: a.Area_Code,
-            name: a.Area_Name,
-            cities: a.Cities,
-            Departments: a.Departments,
-            zoneName: a.Zone_Name,
-            type: "area" as const,
-          }))
-        : zoneList.map((z) => ({
-            code: z.Zone_Code ?? `zone-${z.Zone_Name}`,
-            name: z.Zone_Name,
-            cities: z.Cities,
-            areas: z.Areas,
-            Departments: z.Departments,
-            type: "zone" as const,
-          }));
+        ? areaItems
+        : zoneItems;
+
+    const listSummaryLabel =
+      filterMode === "city"
+        ? `${cityItems.length} cit${cityItems.length === 1 ? "y" : "ies"}`
+        : filterMode === "area"
+        ? `${areaItems.length} area${areaItems.length === 1 ? "" : "s"}`
+        : `${zoneItems.length} zone${zoneItems.length === 1 ? "" : "s"}`;
+
+    const getSecondaryText = (item: SidebarItem) => {
+      if (item.type === "city") {
+        const parts = [
+          `${item.storeCount} store${item.storeCount === 1 ? "" : "s"}`,
+        ];
+        if (item.areaCount > 0) {
+          parts.push(`${item.areaCount} area${item.areaCount === 1 ? "" : "s"}`);
+        }
+        if (item.totalSqm > 0) {
+          parts.push(`${formatNumber.format(item.totalSqm)} m²`);
+        }
+        if (item.storeCount > 0) {
+          const coverage = Math.round(
+            (item.geocodedCount / item.storeCount) * 100
+          );
+          parts.push(
+            `Geo ${item.geocodedCount}/${item.storeCount} (${coverage}%)`
+          );
+        }
+        return parts.join(" • ");
+      }
+
+      if (item.type === "area") {
+        const parts = [
+          `${item.storeCount} store${item.storeCount === 1 ? "" : "s"}`,
+          `${item.cities.length} cit${item.cities.length === 1 ? "y" : "ies"}`,
+        ];
+        if (item.totalSqm > 0) {
+          parts.push(`${formatNumber.format(item.totalSqm)} m²`);
+        }
+        if (item.storeCount > 0) {
+          const coverage = Math.round(
+            (item.geocodedCount / item.storeCount) * 100
+          );
+          parts.push(
+            `Geo ${item.geocodedCount}/${item.storeCount} (${coverage}%)`
+          );
+        }
+        if (item.zoneNames.length > 0) {
+          parts.push(
+            item.zoneNames.length === 1
+              ? `Zone ${item.zoneNames[0]}`
+              : `${item.zoneNames.length} zones`
+          );
+        }
+        return parts.join(" • ");
+      }
+
+      const parts = [
+        `${item.storeCount} store${item.storeCount === 1 ? "" : "s"}`,
+        `${item.areas.length} area${item.areas.length === 1 ? "" : "s"}`,
+      ];
+      if (item.cities.length > 0) {
+        parts.push(`${item.cities.length} cit${item.cities.length === 1 ? "y" : "ies"}`);
+      }
+      if (item.totalSqm > 0) {
+        parts.push(`${formatNumber.format(item.totalSqm)} m²`);
+      }
+      if (item.storeCount > 0) {
+        const coverage = Math.round((item.geocodedCount / item.storeCount) * 100);
+        parts.push(`Geo ${item.geocodedCount}/${item.storeCount} (${coverage}%)`);
+      }
+      if (item.regionNames.length > 0) {
+        parts.push(
+          item.regionNames.length === 1
+            ? `Region ${item.regionNames[0]}`
+            : `${item.regionNames.length} regions`
+        );
+      }
+      return parts.join(" • ");
+    };
 
     drawerContent = (
       <Box
@@ -400,38 +825,109 @@ export default function App() {
             <ToggleButton value="area">Areas</ToggleButton>
             <ToggleButton value="zone">Zones</ToggleButton>
           </ToggleButtonGroup>
+          {!loading && (
+            <Typography
+              variant="caption"
+              sx={{ color: "text.secondary", display: "block", mt: 0.75 }}
+            >
+              {listSummaryLabel}
+            </Typography>
+          )}
         </Box>
 
         <Box sx={{ px: 1, py: 1, flex: 1, overflowY: "auto" }}>
-          <List disablePadding>
-            {items.map((item) => (
-              <ListItemButton
-                key={item.code}
-                selected={selectedItem?.code === item.code}
-                onClick={() => handleSelect(item)}
-                sx={{
-                  borderRadius: 2,
-                  mb: 0.5,
-                  "&.Mui-selected": {
-                    bgcolor: "primary.main",
-                    color: "black",
-                    "& .MuiListItemIcon-root": { color: "black" },
-                  },
-                }}
-              >
-                <ListItemIcon sx={{ color: "text.secondary" }}>
+          {loading ? (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                justifyContent: "center",
+                height: "100%",
+              }}
+            >
+              <CircularProgress size={18} />
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                Loading Viva Fresh network…
+              </Typography>
+            </Box>
+          ) : error ? (
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: 1,
+                textAlign: "center",
+                height: "100%",
+                px: 2,
+              }}
+            >
+              <Typography variant="body2" color="error">
+                {error}
+              </Typography>
+              <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                Refresh the page once the API is back online.
+              </Typography>
+            </Box>
+          ) : items.length === 0 ? (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                height: "100%",
+              }}
+            >
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                No results available yet.
+              </Typography>
+            </Box>
+          ) : (
+            <List disablePadding>
+              {items.map((item) => {
+                const isSelected = selectedItem?.code === item.code;
+                return (
+                  <ListItemButton
+                    key={item.code}
+                    selected={isSelected}
+                    onClick={() => handleSelect(item)}
+                    sx={{
+                      borderRadius: 2,
+                      mb: 0.5,
+                      alignItems: "flex-start",
+                      "&.Mui-selected": {
+                        bgcolor: "primary.main",
+                        color: "black",
+                        "& .MuiListItemIcon-root": { color: "black" },
+                      },
+                    }}
+                  >
+                    <ListItemIcon sx={{ color: "text.secondary", mt: 0.5 }}>
                   {filterMode === "city" ? (
                     <LocationCity />
                   ) : filterMode === "area" ? (
-                    <Map />
+                    <MapIcon />
                   ) : (
                     <Layers />
                   )}
-                </ListItemIcon>
-                <ListItemText primary={item.name} />
-              </ListItemButton>
-            ))}
-          </List>
+                    </ListItemIcon>
+                    <ListItemText
+                      primaryTypographyProps={{ fontWeight: 600 }}
+                      secondaryTypographyProps={{
+                        sx: {
+                          color: isSelected ? "rgba(15,23,42,0.75)" : "text.secondary",
+                        },
+                      }}
+                      primary={item.name}
+                      secondary={getSecondaryText(item)}
+                    />
+                  </ListItemButton>
+                );
+              })}
+            </List>
+          )}
         </Box>
 
         <Divider sx={{ my: 1, borderColor: "divider" }} />
@@ -513,6 +1009,7 @@ export default function App() {
                   <MapView
                     selection={mapSelection}
                     cities={cityList}
+                    stores={storesForMap}
                   />
                 }
               />


### PR DESCRIPTION
## Summary
- reshape API responses to calculate enriched city, area, and zone metrics, build store datasets for the map, and track geocoded coverage
- refresh the sidebar with metric-driven list items, loading/error handling, and detailed panels for areas and zones
- update the map view to consume shared store data, fall back to zone records when needed, and surface quick-reporting and geo coverage cues in the selection overlay

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c91759e2ec8324be0f06dcbaa0f715