### PR TITLE
Align navigation layout spacing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { darkTheme } from "./theme/darkTheme";
 import { formatNumber } from "./utils/format";
 
 const drawerWidth = 300;
+const appBarHeight = { xs: 92, md: 104 } as const;
 
 const resolveMapSelection = (
   filterMode: FilterMode,
@@ -153,6 +154,8 @@ export default function App() {
           elevation={1}
           sx={{
             zIndex: (theme) => theme.zIndex.drawer + 1,
+            ml: `${drawerWidth}px`,
+            width: `calc(100% - ${drawerWidth}px)`,
             background:
               "linear-gradient(120deg, rgba(15,23,42,0.95) 0%, rgba(30,64,175,0.82) 60%, rgba(12,74,110,0.85) 100%)",
             borderBottom: "1px solid rgba(148, 163, 184, 0.25)",
@@ -161,6 +164,7 @@ export default function App() {
         >
           <Toolbar
             sx={{
+              minHeight: appBarHeight,
               px: { xs: 2, lg: 3 },
               py: { xs: 1.5, md: 2 },
               gap: 3,
@@ -296,7 +300,7 @@ export default function App() {
             height: "100vh",
           }}
         >
-          <Toolbar sx={{ minHeight: { xs: 92, md: 104 } }} />
+          <Toolbar sx={{ minHeight: appBarHeight }} />
           <Box sx={{ flex: 1, minHeight: 0 }}>
             <Routes>
               <Route

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -107,6 +107,8 @@ const getSecondaryText = (item: SidebarItem): string => {
   return parts.join(" • ");
 };
 
+const toolbarOffsetSx = { minHeight: { xs: 92, md: 104 } } as const;
+
 const AreaDetail = ({ area, onBack }: { area: SidebarAreaItem; onBack: () => void }) => {
   const areaGeoCoverage =
     area.storeCount > 0
@@ -125,7 +127,7 @@ const AreaDetail = ({ area, onBack }: { area: SidebarAreaItem; onBack: () => voi
 
   return (
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
-      <Toolbar />
+      <Toolbar sx={toolbarOffsetSx} />
       <Box sx={{ px: 2, py: 1 }}>
         <Button variant="outlined" size="small" onClick={onBack} sx={{ mb: 2 }}>
           ← Back to Areas
@@ -232,7 +234,7 @@ const ZoneDetail = ({ zone, onBack }: { zone: SidebarZoneItem; onBack: () => voi
 
   return (
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
-      <Toolbar />
+      <Toolbar sx={toolbarOffsetSx} />
       <Box sx={{ px: 2, py: 1 }}>
         <Button variant="outlined" size="small" onClick={onBack} sx={{ mb: 2 }}>
           ← Back to Zones
@@ -356,7 +358,7 @@ const ListView = ({
         bgcolor: "background.paper",
       }}
     >
-      <Toolbar />
+      <Toolbar sx={toolbarOffsetSx} />
       <Box sx={{ px: 2, py: 1 }}>
         <ToggleButtonGroup
           value={filterMode}


### PR DESCRIPTION
## Summary
- offset the fixed app bar by the drawer width so the header no longer overlays the sidebar
- reuse a shared app bar height value in the main content and sidebar toolbars to keep navigation spacing consistent

## Testing
- npx tsc -b
- CI=1 npx vite build --logLevel warn

------
https://chatgpt.com/codex/tasks/task_e_68c98ea93da48324b1ba7ffeb2973fca