### PR TITLE
Fix zone mapping to restore frontend data

### DIFF
--- a/src/models/viva.ts
+++ b/src/models/viva.ts
@@ -36,6 +36,8 @@ export interface RawAreaResponse {
 export interface RawZoneRecord {
   Zone_Code: string | null;
   Zone_Name: string;
+  Department_Code: string | null;
+  Department_Name: string | null;
   Area_Code: string | null;
   Area_Name: string;
   City_Name: string | null;

--- a/src/utils/dataTransforms.ts
+++ b/src/utils/dataTransforms.ts
@@ -65,6 +65,12 @@ const buildZoneGroups = (zones: RawZoneRecord[]): ZoneGroup[] => {
     const zoneCodeRaw = String(baseCode ?? `zone-${record.Zone_Name}`).trim();
     const zoneCode = zoneCodeRaw.length > 0 ? zoneCodeRaw : `zone-${record.Zone_Name}`;
     const zoneName = record.Zone_Name?.trim() || "Unassigned zone";
+    const departmentCodeRaw = record.Department_Code ?? record.Zone_Code;
+    const departmentCode = String(departmentCodeRaw ?? "").trim();
+    const departmentName =
+      record.Department_Name?.trim() ||
+      record.Zone_Name?.trim() ||
+      "Unassigned department";
 
     let group = groups.get(zoneCode);
     if (!group) {
@@ -82,8 +88,8 @@ const buildZoneGroups = (zones: RawZoneRecord[]): ZoneGroup[] => {
     }
 
     const department: Department = {
-      Department_Code: zoneCode,
-      Department_Name: zoneName,
+      Department_Code: departmentCode.length > 0 ? departmentCode : zoneCode,
+      Department_Name: departmentName,
       SQM: record.SQM,
       Longitude: record.Longitude,
       Latitude: record.Latitude,
@@ -118,7 +124,7 @@ const buildZoneByDepartmentIndex = (
 ): Map<string, RawZoneRecord> => {
   const index = new Map<string, RawZoneRecord>();
   for (const record of zones) {
-    const rawKey = record.Zone_Code ?? record.Zone_Name;
+    const rawKey = record.Department_Code ?? record.Zone_Code ?? record.Zone_Name;
     if (!rawKey) {
       continue;
     }


### PR DESCRIPTION
## Summary
- include department metadata on zone API records consumed by the frontend types
- align zone aggregation logic to use the department code and name when grouping and indexing
- ensure departments resolve to their proper zones so area and zone views display data again

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cab44d7fbc832492cba47019a37698