### PR TITLE
Fix API base URL fallback

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,8 +1,10 @@
 import axios from "axios";
 
+import { API_BASE_URL } from "./config/apiConfig";
+
 // Base URL for backend API
 const API = axios.create({
-  baseURL: "http://localhost:4000/api", // change to http://192.168.100.63:4000 for LAN
+  baseURL: API_BASE_URL,
   timeout: 5000,
 });
 

--- a/src/config/apiConfig.ts
+++ b/src/config/apiConfig.ts
@@ -1,5 +1,14 @@
+const inferBrowserBaseUrl = () => {
+  if (typeof window === "undefined" || !window.location?.origin) {
+    return null;
+  }
+
+  return `${window.location.origin}/api`;
+};
+
 const rawBaseUrl =
   (import.meta.env?.VITE_API_BASE_URL as string | undefined) ??
+  inferBrowserBaseUrl() ??
   "http://localhost:4000/api";
 
 export const API_BASE_URL = rawBaseUrl.replace(/\/+$/, "");


### PR DESCRIPTION
## Summary
- derive the default API base URL from the browser origin when no environment override is provided
- share the computed API base URL with the axios client used by legacy helpers

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cab44d7fbc832492cba47019a37698