### PR TITLE
Fix API base URL default for frontend data loading

### DIFF
--- a/src/config/apiConfig.ts
+++ b/src/config/apiConfig.ts
@@ -1,8 +1,18 @@
-const rawBaseUrl =
-  (import.meta.env?.VITE_API_BASE_URL as string | undefined) ??
-  "http://localhost:4000/api";
+const normalizeBaseUrl = (value: string): string => value.replace(/\/+$/, "");
 
-export const API_BASE_URL = rawBaseUrl.replace(/\/+$/, "");
+const getDefaultBaseUrl = (): string => {
+  if (typeof window !== "undefined" && window.location) {
+    return `${window.location.origin}/api`;
+  }
+
+  return "http://localhost:4000/api";
+};
+
+const rawBaseUrl =
+  (import.meta.env?.VITE_API_BASE_URL as string | undefined)?.trim() ??
+  getDefaultBaseUrl();
+
+export const API_BASE_URL = normalizeBaseUrl(rawBaseUrl);
 
 export const buildApiUrl = (path: string): string =>
   `${API_BASE_URL}${path.startsWith("/") ? "" : "/"}${path}`;


### PR DESCRIPTION
## Summary
- default the frontend API base URL to the current window origin when no VITE_API_BASE_URL is provided
- retain localhost fallback for non-browser contexts while trimming trailing slashes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cab44d7fbc832492cba47019a37698